### PR TITLE
fix(e2e-mdb): Regenerate lockfile for pinned deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,15 +126,15 @@ importers:
         specifier: 6.3.0
         version: 6.3.0
       mongodb-memory-server:
-        specifier: ^10.0.0
+        specifier: 10.4.3
         version: 10.4.3
       yaml:
-        specifier: ^2.3.4
+        specifier: 2.8.2
         version: 2.8.2
     devDependencies:
       '@playwright/test':
-        specifier: ^1.40.0
-        version: 1.58.1
+        specifier: 1.50.1
+        version: 1.50.1
       '@swc/cli':
         specifier: 0.1.62
         version: 0.1.62(@swc/core@1.3.96)
@@ -377,7 +377,7 @@ packages:
       '@smithy/util-defaults-mode-node': 2.0.2
       '@smithy/util-retry': 2.0.0
       '@smithy/util-utf8': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -420,7 +420,7 @@ packages:
       '@smithy/util-defaults-mode-node': 2.0.2
       '@smithy/util-retry': 2.0.0
       '@smithy/util-utf8': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -467,7 +467,7 @@ packages:
       '@smithy/util-retry': 2.0.0
       '@smithy/util-utf8': 2.0.0
       fast-xml-parser: 4.2.5
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -482,7 +482,7 @@ packages:
       '@aws-sdk/types': 3.378.0
       '@smithy/property-provider': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -496,7 +496,7 @@ packages:
       '@aws-sdk/types': 3.378.0
       '@smithy/property-provider': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -514,7 +514,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/shared-ini-file-loader': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -535,7 +535,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/shared-ini-file-loader': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -550,7 +550,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/shared-ini-file-loader': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -565,7 +565,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/shared-ini-file-loader': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -579,7 +579,7 @@ packages:
       '@aws-sdk/types': 3.378.0
       '@smithy/property-provider': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -602,7 +602,7 @@ packages:
       '@smithy/credential-provider-imds': 2.0.2
       '@smithy/property-provider': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -616,7 +616,7 @@ packages:
       '@aws-sdk/types': 3.378.0
       '@smithy/protocol-http': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -627,7 +627,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.378.0
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -639,7 +639,7 @@ packages:
       '@aws-sdk/types': 3.378.0
       '@smithy/protocol-http': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -651,7 +651,7 @@ packages:
       '@aws-sdk/middleware-signing': 3.379.1
       '@aws-sdk/types': 3.378.0
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -666,7 +666,7 @@ packages:
       '@smithy/signature-v4': 2.0.2
       '@smithy/types': 2.1.0
       '@smithy/util-middleware': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -679,7 +679,7 @@ packages:
       '@aws-sdk/util-endpoints': 3.386.0
       '@smithy/protocol-http': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -692,7 +692,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/shared-ini-file-loader': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -702,7 +702,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -712,7 +712,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@aws-sdk/types': 3.378.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -721,7 +721,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -732,7 +732,7 @@ packages:
       '@aws-sdk/types': 3.378.0
       '@smithy/types': 2.1.0
       bowser: 2.11.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -749,7 +749,7 @@ packages:
       '@aws-sdk/types': 3.378.0
       '@smithy/node-config-provider': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -757,7 +757,7 @@ packages:
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -1791,6 +1791,7 @@ packages:
 
   /@mongodb-js/saslprep@1.4.5:
     resolution: {integrity: sha512-k64Lbyb7ycCSXHSLzxVdb2xsKGPMvYZfCICXvDsI8Z65CeWQzTEKS4YmGbnqw+U9RBvLPTsB6UCmwkgsDTGWIw==}
+    requiresBuild: true
     dependencies:
       sparse-bitfield: 3.0.3
     dev: false
@@ -1934,12 +1935,12 @@ packages:
       tslib: 2.6.1
     dev: true
 
-  /@playwright/test@1.58.1:
-    resolution: {integrity: sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==}
+  /@playwright/test@1.50.1:
+    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.58.1
+      playwright: 1.50.1
     dev: true
 
   /@shelf/jest-mongodb@4.1.4(jest-environment-node@28.1.3)(mongodb@6.3.0):
@@ -1984,7 +1985,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -1996,7 +1997,7 @@ packages:
       '@smithy/types': 2.1.0
       '@smithy/util-config-provider': 2.0.0
       '@smithy/util-middleware': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2009,7 +2010,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/types': 2.1.0
       '@smithy/url-parser': 2.0.2
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2020,7 +2021,7 @@ packages:
       '@aws-crypto/crc32': 3.0.0
       '@smithy/types': 2.1.0
       '@smithy/util-hex-encoding': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2032,7 +2033,7 @@ packages:
       '@smithy/querystring-builder': 2.0.2
       '@smithy/types': 2.1.0
       '@smithy/util-base64': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2044,7 +2045,7 @@ packages:
       '@smithy/types': 2.1.0
       '@smithy/util-buffer-from': 2.0.0
       '@smithy/util-utf8': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2053,7 +2054,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2062,7 +2063,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2073,7 +2074,7 @@ packages:
     dependencies:
       '@smithy/protocol-http': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2086,7 +2087,7 @@ packages:
       '@smithy/types': 2.1.0
       '@smithy/url-parser': 2.0.2
       '@smithy/util-middleware': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2100,7 +2101,7 @@ packages:
       '@smithy/types': 2.1.0
       '@smithy/util-middleware': 2.0.0
       '@smithy/util-retry': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
       uuid: 8.3.2
     dev: false
     optional: true
@@ -2111,7 +2112,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2120,7 +2121,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2132,7 +2133,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/shared-ini-file-loader': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2145,7 +2146,7 @@ packages:
       '@smithy/protocol-http': 2.0.2
       '@smithy/querystring-builder': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2155,7 +2156,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2165,7 +2166,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2176,7 +2177,7 @@ packages:
     dependencies:
       '@smithy/types': 2.1.0
       '@smithy/util-uri-escape': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2186,7 +2187,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2203,7 +2204,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2219,7 +2220,7 @@ packages:
       '@smithy/util-middleware': 2.0.0
       '@smithy/util-uri-escape': 2.0.0
       '@smithy/util-utf8': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2231,7 +2232,7 @@ packages:
       '@smithy/middleware-stack': 2.0.0
       '@smithy/types': 2.1.0
       '@smithy/util-stream': 2.0.2
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2240,7 +2241,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2250,7 +2251,7 @@ packages:
     dependencies:
       '@smithy/querystring-parser': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2260,7 +2261,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/util-buffer-from': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2268,7 +2269,7 @@ packages:
     resolution: {integrity: sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2277,7 +2278,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2287,7 +2288,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/is-array-buffer': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2296,7 +2297,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2308,7 +2309,7 @@ packages:
       '@smithy/property-provider': 2.0.2
       '@smithy/types': 2.1.0
       bowser: 2.11.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2322,7 +2323,7 @@ packages:
       '@smithy/node-config-provider': 2.0.2
       '@smithy/property-provider': 2.0.2
       '@smithy/types': 2.1.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2331,7 +2332,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2340,7 +2341,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2350,7 +2351,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/service-error-classification': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2366,7 +2367,7 @@ packages:
       '@smithy/util-buffer-from': 2.0.0
       '@smithy/util-hex-encoding': 2.0.0
       '@smithy/util-utf8': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2375,7 +2376,7 @@ packages:
     engines: {node: '>=14.0.0'}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2385,7 +2386,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@smithy/util-buffer-from': 2.0.0
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
     optional: true
 
@@ -2686,7 +2687,7 @@ packages:
   /@swc/helpers@0.5.2:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.8.1
     dev: false
 
   /@swc/jest@0.2.21(@swc/core@1.2.194):
@@ -6697,7 +6698,7 @@ packages:
       socks: 2.7.1
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.386.0
-      '@mongodb-js/saslprep': 1.1.1
+      '@mongodb-js/saslprep': 1.4.5
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -7275,18 +7276,18 @@ packages:
     dependencies:
       find-up: 4.1.0
 
-  /playwright-core@1.58.1:
-    resolution: {integrity: sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==}
+  /playwright-core@1.50.1:
+    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
     engines: {node: '>=18'}
     hasBin: true
     dev: true
 
-  /playwright@1.58.1:
-    resolution: {integrity: sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==}
+  /playwright@1.50.1:
+    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.58.1
+      playwright-core: 1.50.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -8406,6 +8407,7 @@ packages:
 
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
+    dev: true
 
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}


### PR DESCRIPTION
## Summary
- Regenerates `pnpm-lock.yaml` to match the pinned dependency versions in `community-plugin-e2e-mdb/package.json`
- Fixes `ERR_PNPM_OUTDATED_LOCKFILE` when running `pnpm install --frozen-lockfile` in CI

## Test plan
- [ ] CI passes with `--frozen-lockfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)