### PR TITLE
feat(e2e-mdb): Add configureMdb() with secret override and replica set support

### DIFF
--- a/.changeset/e2e-secret-override.md
+++ b/.changeset/e2e-secret-override.md
@@ -1,0 +1,5 @@
+---
+"@lowdefy/community-plugin-e2e-mdb": minor
+---
+
+Set LOWDEFY_E2E_SECRET_MONGODB_URI and LOWDEFY_SECRET_MONGODB_URI in globalSetup so MongoMemoryServer URI survives secret-manager injection via commandPrefix.

--- a/plugins/community-plugin-e2e-mdb/README.md
+++ b/plugins/community-plugin-e2e-mdb/README.md
@@ -14,16 +14,30 @@ pnpm add @lowdefy/community-plugin-e2e-mdb
 
 ### Playwright Configuration
 
-Configure your `playwright.config.js`:
+Configure your `playwright.config.js`. Call `configureMdb()` **before** `createConfig()` — Playwright starts the webServer before globalSetup, so environment variables must be set at config evaluation time.
 
 ```javascript
-import { defineConfig } from '@playwright/test';
+import { configureMdb } from '@lowdefy/community-plugin-e2e-mdb/config';
+import { createConfig } from '@lowdefy/e2e-utils/config';
 
-export default defineConfig({
+// Set MongoDB env vars at config time (before webServer starts)
+configureMdb();
+
+const config = createConfig({
+  /* ... */
+});
+
+export default {
+  ...config,
   globalSetup: '@lowdefy/community-plugin-e2e-mdb/setup',
   globalTeardown: '@lowdefy/community-plugin-e2e-mdb/teardown',
-  // ... other config
-});
+};
+```
+
+`configureMdb()` accepts optional overrides and returns the URI:
+
+```javascript
+const uri = configureMdb({ port: 27200, databaseName: 'my_test_db' });
 ```
 
 ### Using the Fixtures

--- a/plugins/community-plugin-e2e-mdb/README.md
+++ b/plugins/community-plugin-e2e-mdb/README.md
@@ -17,7 +17,7 @@ pnpm add @lowdefy/community-plugin-e2e-mdb
 Configure your `playwright.config.js`. Call `configureMdb()` **before** `createConfig()` — Playwright starts the webServer before globalSetup, so environment variables must be set at config evaluation time.
 
 ```javascript
-import { configureMdb } from '@lowdefy/community-plugin-e2e-mdb/config';
+import configureMdb from '@lowdefy/community-plugin-e2e-mdb/config';
 import { createConfig } from '@lowdefy/e2e-utils/config';
 
 // Set MongoDB env vars at config time (before webServer starts)
@@ -38,6 +38,12 @@ export default {
 
 ```javascript
 const uri = configureMdb({ port: 27200, databaseName: 'my_test_db' });
+```
+
+By default, a single-node replica set is started so that MongoDB transactions work (required by `MongoDBInsertConsecutiveId` and other operations). To use a standalone instance instead:
+
+```javascript
+configureMdb({ replicaSet: false });
 ```
 
 ### Using the Fixtures

--- a/plugins/community-plugin-e2e-mdb/README.md
+++ b/plugins/community-plugin-e2e-mdb/README.md
@@ -152,8 +152,8 @@ createdAt: !date 2024-01-15T10:30:00.000Z
 
 ## Environment Variables
 
-- `MDB_E2E_URI`: MongoDB connection URI (set automatically by globalSetup)
-- `MDB_E2E_PORT`: Port for the in-memory MongoDB server (default: `27117`)
+- `LOWDEFY_E2E_MONGODB_URI`: MongoDB connection URI (set automatically by globalSetup)
+- `LOWDEFY_E2E_MONGODB_PORT`: Port for the in-memory MongoDB server (default: `27117`)
 - `LOWDEFY_E2E_SECRET_MONGODB_URI`: Set automatically by globalSetup. Overrides `LOWDEFY_SECRET_MONGODB_URI` in server-e2e so the MongoMemoryServer URI survives secret-manager injection via `commandPrefix`.
 - `LOWDEFY_SECRET_MONGODB_URI`: Set automatically by globalSetup for backwards compatibility with server-e2e versions that don't support `LOWDEFY_E2E_SECRET_*`.
 
@@ -195,10 +195,10 @@ const mdb = createMdbHelper(db, {
 
 ### Using with Existing MongoDB
 
-If you have an existing MongoDB instance, skip the global setup/teardown and set `MDB_E2E_URI`:
+If you have an existing MongoDB instance, skip the global setup/teardown and set `LOWDEFY_E2E_MONGODB_URI`:
 
 ```bash
-MDB_E2E_URI=mongodb://localhost:27017 npx playwright test
+LOWDEFY_E2E_MONGODB_URI=mongodb://localhost:27017 npx playwright test
 ```
 
 ## License

--- a/plugins/community-plugin-e2e-mdb/README.md
+++ b/plugins/community-plugin-e2e-mdb/README.md
@@ -117,6 +117,7 @@ Direct access to the MongoDB database instance.
 Snap files are YAML files stored in `<testDir>/snaps/<snapName>/<collectionName>.yaml`.
 
 Example structure:
+
 ```
 tests/
   snaps/
@@ -129,6 +130,7 @@ tests/
 ```
 
 Example YAML file (`users.yaml`):
+
 ```yaml
 - _id: user1
   name: Alice
@@ -143,6 +145,7 @@ Example YAML file (`users.yaml`):
 ### Date Handling
 
 Use the `!date` tag for Date values:
+
 ```yaml
 createdAt: !date 2024-01-15T10:30:00.000Z
 ```
@@ -151,6 +154,25 @@ createdAt: !date 2024-01-15T10:30:00.000Z
 
 - `MDB_E2E_URI`: MongoDB connection URI (set automatically by globalSetup)
 - `MDB_E2E_PORT`: Port for the in-memory MongoDB server (default: `27117`)
+- `LOWDEFY_E2E_SECRET_MONGODB_URI`: Set automatically by globalSetup. Overrides `LOWDEFY_SECRET_MONGODB_URI` in server-e2e so the MongoMemoryServer URI survives secret-manager injection via `commandPrefix`.
+- `LOWDEFY_SECRET_MONGODB_URI`: Set automatically by globalSetup for backwards compatibility with server-e2e versions that don't support `LOWDEFY_E2E_SECRET_*`.
+
+### Overriding Secrets in E2E Tests
+
+When using a secret manager (e.g. Infisical, Doppler) via `commandPrefix` in your Lowdefy e2e config, the secret manager injects `LOWDEFY_SECRET_*` env vars that can override values set by test infrastructure. The `LOWDEFY_E2E_SECRET_*` prefix (supported in server-e2e via [lowdefy/lowdefy#2058](https://github.com/lowdefy/lowdefy/issues/2058)) takes precedence over `LOWDEFY_SECRET_*` during secret resolution, ensuring test-infrastructure values win.
+
+This plugin sets `LOWDEFY_E2E_SECRET_MONGODB_URI` automatically. To override other secrets in your tests, set additional `LOWDEFY_E2E_SECRET_*` env vars in your `playwright.config.js`:
+
+```javascript
+export default defineConfig({
+  use: {
+    // Override any secret that would otherwise come from the secret manager
+    env: {
+      LOWDEFY_E2E_SECRET_MY_API_KEY: 'test-api-key',
+    },
+  },
+});
+```
 
 ## Advanced Usage
 

--- a/plugins/community-plugin-e2e-mdb/package.json
+++ b/plugins/community-plugin-e2e-mdb/package.json
@@ -7,7 +7,8 @@
     ".": "./dist/index.js",
     "./fixtures": "./dist/fixtures/index.js",
     "./setup": "./dist/setup/globalSetup.js",
-    "./teardown": "./dist/setup/globalTeardown.js"
+    "./teardown": "./dist/setup/globalTeardown.js",
+    "./config": "./dist/config/configureMdb.js"
   },
   "files": [
     "dist/*"

--- a/plugins/community-plugin-e2e-mdb/src/config/configureMdb.js
+++ b/plugins/community-plugin-e2e-mdb/src/config/configureMdb.js
@@ -1,0 +1,49 @@
+/*
+  Copyright 2020-2024 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/**
+ * Configure MongoDB e2e environment variables at config evaluation time.
+ *
+ * Call this in playwright.config.js BEFORE createConfig() — Playwright starts
+ * the webServer before globalSetup, so env vars must be set at config time
+ * for the server process to inherit them.
+ *
+ * globalSetup then starts MongoMemoryServer on the configured port.
+ *
+ * @param {Object} [options]
+ * @param {number} [options.port=27117] - Port for MongoMemoryServer
+ * @param {string} [options.databaseName='e2e_test'] - Database name
+ * @returns {string} The MongoDB URI
+ */
+function configureMdb({ port, databaseName } = {}) {
+  const mdbPort = port || parseInt(process.env.LOWDEFY_E2E_MONGODB_PORT) || 27117;
+  const dbName = databaseName || 'e2e_test';
+  const uri = `mongodb://127.0.0.1:${mdbPort}/${dbName}`;
+
+  // Set the URI for the mdb plugin fixtures and globalSetup
+  process.env.LOWDEFY_E2E_MONGODB_URI = uri;
+  process.env.LOWDEFY_E2E_MONGODB_PORT = String(mdbPort);
+
+  // Set Lowdefy secret overrides so the server connects to MongoMemoryServer.
+  // LOWDEFY_E2E_SECRET_* takes precedence over LOWDEFY_SECRET_* in server-e2e.
+  // Both are set for backwards compatibility.
+  process.env.LOWDEFY_E2E_SECRET_MONGODB_URI = uri;
+  process.env.LOWDEFY_SECRET_MONGODB_URI = uri;
+
+  return uri;
+}
+
+export default configureMdb;

--- a/plugins/community-plugin-e2e-mdb/src/config/configureMdb.js
+++ b/plugins/community-plugin-e2e-mdb/src/config/configureMdb.js
@@ -23,15 +23,26 @@
  *
  * globalSetup then starts MongoMemoryServer on the configured port.
  *
+ * By default, a single-node replica set is used so that transactions
+ * (required by MongoDBInsertConsecutiveId and other operations) work.
+ * Pass `replicaSet: false` to use a standalone instance instead.
+ *
  * @param {Object} [options]
  * @param {number} [options.port=27117] - Port for MongoMemoryServer
  * @param {string} [options.databaseName='e2e_test'] - Database name
+ * @param {string|false} [options.replicaSet='testset'] - Replica set name, or false for standalone
  * @returns {string} The MongoDB URI
  */
-function configureMdb({ port, databaseName } = {}) {
+function configureMdb({ port, databaseName, replicaSet = 'testset' } = {}) {
   const mdbPort = port || parseInt(process.env.LOWDEFY_E2E_MONGODB_PORT) || 27117;
   const dbName = databaseName || 'e2e_test';
-  const uri = `mongodb://127.0.0.1:${mdbPort}/${dbName}`;
+
+  let uri;
+  if (replicaSet) {
+    uri = `mongodb://127.0.0.1:${mdbPort}/${dbName}?replicaSet=${replicaSet}`;
+  } else {
+    uri = `mongodb://127.0.0.1:${mdbPort}/${dbName}`;
+  }
 
   // Set the URI for the mdb plugin fixtures and globalSetup
   process.env.LOWDEFY_E2E_MONGODB_URI = uri;

--- a/plugins/community-plugin-e2e-mdb/src/fixtures/index.js
+++ b/plugins/community-plugin-e2e-mdb/src/fixtures/index.js
@@ -24,8 +24,8 @@ const STATE_FILE = '.mdb-e2e-state.json';
 
 function getMongoUri() {
   // First check environment variable
-  if (process.env.MDB_E2E_URI) {
-    return process.env.MDB_E2E_URI;
+  if (process.env.LOWDEFY_E2E_MONGODB_URI) {
+    return process.env.LOWDEFY_E2E_MONGODB_URI;
   }
 
   // Fallback to state file

--- a/plugins/community-plugin-e2e-mdb/src/index.js
+++ b/plugins/community-plugin-e2e-mdb/src/index.js
@@ -22,6 +22,9 @@ export { createMdbHelper } from './mdb/createMdbHelper.js';
 export { load, snap } from './mdb/snap.js';
 export { seed } from './mdb/seed.js';
 
+// Config-time setup
+export { default as configureMdb } from './config/configureMdb.js';
+
 // Setup functions
 export { default as globalSetup } from './setup/globalSetup.js';
 export { default as globalTeardown } from './setup/globalTeardown.js';

--- a/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
+++ b/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
@@ -17,12 +17,15 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import fs from 'fs';
 import path from 'path';
+import configureMdb from '../config/configureMdb.js';
 
 const STATE_FILE = '.mdb-e2e-state.json';
 
 async function globalSetup() {
-  // Use fixed port for predictable URI (can be set at config time before globalSetup runs)
-  // Default to 27117 to avoid conflict with standard MongoDB port 27017
+  // Ensure env vars are set (idempotent if configureMdb was already called at config time).
+  // When used without configureMdb(), this provides backwards compatibility.
+  configureMdb();
+
   const port = parseInt(process.env.LOWDEFY_E2E_MONGODB_PORT) || 27117;
   const mongod = await MongoMemoryServer.create({
     instance: { port },
@@ -40,20 +43,7 @@ async function globalSetup() {
   // Store instance globally for teardown
   globalThis.__MONGOD__ = mongod;
 
-  // Set environment variable for tests if not already configured
-  // (e.g., with fixed port approach in playwright.config.js that includes a database name)
-  if (!process.env.LOWDEFY_E2E_MONGODB_URI) {
-    process.env.LOWDEFY_E2E_MONGODB_URI = uri;
-  }
-
-  // Set Lowdefy secret env vars so the server resolves to MongoMemoryServer.
-  // LOWDEFY_E2E_SECRET_* overrides LOWDEFY_SECRET_* in server-e2e (lowdefy/lowdefy#2058).
-  // Both are set for backwards compatibility with older server-e2e versions.
-  process.env.LOWDEFY_E2E_SECRET_MONGODB_URI = uri;
-  process.env.LOWDEFY_SECRET_MONGODB_URI = uri;
-
   return async () => {
-    // Cleanup function called by Playwright
     if (globalThis.__MONGOD__) {
       await globalThis.__MONGOD__.stop();
       delete globalThis.__MONGOD__;

--- a/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
+++ b/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoMemoryServer, MongoMemoryReplSet } from 'mongodb-memory-server';
 import fs from 'fs';
 import path from 'path';
 import configureMdb from '../config/configureMdb.js';
@@ -27,15 +27,29 @@ async function globalSetup() {
   configureMdb();
 
   const port = parseInt(process.env.LOWDEFY_E2E_MONGODB_PORT) || 27117;
-  const mongod = await MongoMemoryServer.create({
-    instance: { port },
-  });
-  const uri = mongod.getUri();
+  const uri = process.env.LOWDEFY_E2E_MONGODB_URI || '';
+
+  // Detect replica set mode from the URI configured by configureMdb().
+  const rsMatch = uri.match(/replicaSet=([^&]+)/);
+
+  let mongod;
+  if (rsMatch) {
+    mongod = await MongoMemoryReplSet.create({
+      replSet: { count: 1, name: rsMatch[1] },
+      instanceOpts: [{ port }],
+    });
+  } else {
+    mongod = await MongoMemoryServer.create({
+      instance: { port },
+    });
+  }
+
+  const actualUri = mongod.getUri();
 
   // Store state for teardown and tests
   const state = {
-    uri,
-    instanceId: mongod.instanceInfo?.instance?.pid,
+    uri: actualUri,
+    mode: rsMatch ? 'replset' : 'standalone',
   };
 
   fs.writeFileSync(path.join(process.cwd(), STATE_FILE), JSON.stringify(state, null, 2));

--- a/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
+++ b/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
@@ -35,10 +35,7 @@ async function globalSetup() {
     instanceId: mongod.instanceInfo?.instance?.pid,
   };
 
-  fs.writeFileSync(
-    path.join(process.cwd(), STATE_FILE),
-    JSON.stringify(state, null, 2)
-  );
+  fs.writeFileSync(path.join(process.cwd(), STATE_FILE), JSON.stringify(state, null, 2));
 
   // Store instance globally for teardown
   globalThis.__MONGOD__ = mongod;
@@ -48,6 +45,12 @@ async function globalSetup() {
   if (!process.env.MDB_E2E_URI) {
     process.env.MDB_E2E_URI = uri;
   }
+
+  // Set Lowdefy secret env vars so the server resolves to MongoMemoryServer.
+  // LOWDEFY_E2E_SECRET_* overrides LOWDEFY_SECRET_* in server-e2e (lowdefy/lowdefy#2058).
+  // Both are set for backwards compatibility with older server-e2e versions.
+  process.env.LOWDEFY_E2E_SECRET_MONGODB_URI = uri;
+  process.env.LOWDEFY_SECRET_MONGODB_URI = uri;
 
   return async () => {
     // Cleanup function called by Playwright

--- a/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
+++ b/plugins/community-plugin-e2e-mdb/src/setup/globalSetup.js
@@ -23,7 +23,7 @@ const STATE_FILE = '.mdb-e2e-state.json';
 async function globalSetup() {
   // Use fixed port for predictable URI (can be set at config time before globalSetup runs)
   // Default to 27117 to avoid conflict with standard MongoDB port 27017
-  const port = parseInt(process.env.MDB_E2E_PORT) || 27117;
+  const port = parseInt(process.env.LOWDEFY_E2E_MONGODB_PORT) || 27117;
   const mongod = await MongoMemoryServer.create({
     instance: { port },
   });
@@ -42,8 +42,8 @@ async function globalSetup() {
 
   // Set environment variable for tests if not already configured
   // (e.g., with fixed port approach in playwright.config.js that includes a database name)
-  if (!process.env.MDB_E2E_URI) {
-    process.env.MDB_E2E_URI = uri;
+  if (!process.env.LOWDEFY_E2E_MONGODB_URI) {
+    process.env.LOWDEFY_E2E_MONGODB_URI = uri;
   }
 
   // Set Lowdefy secret env vars so the server resolves to MongoMemoryServer.


### PR DESCRIPTION
## Summary

- Add `configureMdb()` config-time setup function that sets env vars before Playwright's webServer starts
- Set `LOWDEFY_E2E_SECRET_MONGODB_URI` so MongoMemoryServer URI survives secret-manager injection via `commandPrefix`
- Set `LOWDEFY_SECRET_MONGODB_URI` for backwards compatibility with older server-e2e versions
- Rename `MDB_E2E_*` env vars to `LOWDEFY_E2E_MONGODB_*` for consistent naming
- Add replica set support (default enabled) so MongoDB transactions work in e2e tests
- Document `configureMdb()` usage, `LOWDEFY_E2E_SECRET_*` override pattern, and `replicaSet` option in README

**Depends on:** lowdefy/lowdefy#2058

## Test plan

- [ ] Verify `configureMdb()` sets all env vars at config evaluation time
- [ ] Verify globalSetup starts MongoMemoryReplSet in default replica set mode
- [ ] Verify `configureMdb({ replicaSet: false })` falls back to standalone MongoMemoryServer
- [ ] Verify backwards compatibility — globalSetup calls `configureMdb()` idempotently if not called at config time

## PR Checklist
- [ ] `/r:docs-update` - Documentation updated for behavioral changes
- [ ] `/r:review-pr` - Self-review completed before requesting team review

Closes #60