### PR TITLE
fix: Add repository URL to all packages for npm provenance

### DIFF
--- a/plugins/community-plugin-aggrid/package.json
+++ b/plugins/community-plugin-aggrid/package.json
@@ -30,7 +30,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/lowdefy/lowdefy.git"
+    "url": "https://github.com/lowdefy/community-plugins.git"
   },
   "type": "module",
   "exports": {

--- a/plugins/community-plugin-auth/package.json
+++ b/plugins/community-plugin-auth/package.json
@@ -24,5 +24,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/community-plugins.git"
   }
 }

--- a/plugins/community-plugin-confetti/package.json
+++ b/plugins/community-plugin-confetti/package.json
@@ -23,5 +23,9 @@
   },
   "dependencies": {
     "js-confetti": "0.11.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/community-plugins.git"
   }
 }

--- a/plugins/community-plugin-e2e-mdb/package.json
+++ b/plugins/community-plugin-e2e-mdb/package.json
@@ -32,5 +32,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/community-plugins.git"
   }
 }

--- a/plugins/community-plugin-js/package.json
+++ b/plugins/community-plugin-js/package.json
@@ -20,5 +20,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/community-plugins.git"
   }
 }

--- a/plugins/community-plugin-mongodb/package.json
+++ b/plugins/community-plugin-mongodb/package.json
@@ -35,5 +35,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/community-plugins.git"
   }
 }

--- a/plugins/community-plugin-nodemailer/package.json
+++ b/plugins/community-plugin-nodemailer/package.json
@@ -25,5 +25,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/community-plugins.git"
   }
 }

--- a/plugins/community-plugin-xlsx/package.json
+++ b/plugins/community-plugin-xlsx/package.json
@@ -24,5 +24,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lowdefy/community-plugins.git"
   }
 }


### PR DESCRIPTION
## Summary
- Add `repository.url` to all 8 plugin `package.json` files pointing to `https://github.com/lowdefy/community-plugins.git`
- Fix `community-plugin-aggrid` which incorrectly pointed to `lowdefy/lowdefy.git`
- Required for npm trusted publishing — provenance validation checks that `repository.url` matches the GitHub repo

## Test plan
- [ ] Merge and verify release workflow publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)