### PR TITLE
Add MongoDBChangeStream websocket type

### DIFF
--- a/apps/docs/community-plugin-mongodb/MongoDB.yaml
+++ b/apps/docs/community-plugin-mongodb/MongoDB.yaml
@@ -276,3 +276,65 @@ _ref:
                 {"_id": ObjectId("..."), "entity_id": 123, "name": "New Name", "value": 33, "updated_at": ISODate("2024-11-01")},
               ]
             ```
+
+            ## Websockets
+
+            Websocket types:
+              - MongoDBChangeStream
+
+            ### MongoDBChangeStream
+
+            The `MongoDBChangeStream` websocket opens a MongoDB [change stream](https://www.mongodb.com/docs/manual/changeStreams/) on the collection specified in the connection, and pushes every change event to subscribed pages in real time. The source starts when the first page subscribes and stops when the last one leaves — any number of subscribers share one change stream.
+
+            Properties are evaluated per subscription, so `_user` and `_payload` operators in the `pipeline` produce user-specific streams.
+
+            > Change streams require MongoDB to run as a replica set — they are not available on standalone deployments. MongoDB Atlas clusters support them out of the box. Websockets require Lowdefy v5.4 or later.
+
+            #### Properties
+
+            - `pipeline: object[]`: An array of [aggregation pipeline stages](https://www.mongodb.com/docs/manual/changeStreams/#modify-change-stream-output) applied to the change stream, e.g. `$match` on `operationType` or `fullDocument` fields.
+            - `fullDocument: string`: The change stream [fullDocument](https://www.mongodb.com/docs/manual/reference/method/db.collection.watch/) option. Defaults to `updateLookup`, which includes the current document on update events.
+
+            #### Example
+
+            ###### Refetch a table when the user's orders change:
+            ```yaml
+            websockets:
+              - id: order_updates
+                type: MongoDBChangeStream
+                connectionId: my_mongodb_collection_id
+                properties:
+                  pipeline:
+                    - $match:
+                        operationType:
+                          $in:
+                            - insert
+                            - update
+                        fullDocument.owner_id:
+                          _user: id
+
+            pages:
+              - id: orders
+                type: PageHeaderMenu
+                requests:
+                  - id: get_orders
+                    type: MongoDBFind
+                    connectionId: my_mongodb_collection_id
+                    properties:
+                      query:
+                        owner_id:
+                          _user: id
+                subscriptions:
+                  - websocketId: order_updates
+                    events:
+                      onMessage:
+                        - id: refetch
+                          type: Request
+                          params: get_orders
+                blocks:
+                  - id: orders_table
+                    type: AgGridAlpine
+                    properties:
+                      rowData:
+                        _request: get_orders
+            ```

--- a/plugins/community-plugin-mongodb/package.json
+++ b/plugins/community-plugin-mongodb/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./auth/adapters": "./dist/auth/adapters.js",
     "./connections": "./dist/connections.js",
-    "./types": "./dist/types.js"
+    "./types": "./dist/types.js",
+    "./websockets": "./dist/websockets.js"
   },
   "files": [
     "dist/*"

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.js
@@ -1,0 +1,65 @@
+/*
+  Copyright 2020-2023 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import getCollection from '../getCollection.js';
+import { serialize, deserialize } from '../serialize.js';
+import schema from './schema.js';
+
+// Websocket source resolver — opens a MongoDB change stream and publishes
+// each change event to the channel's subscribers. Runs from the first
+// subscriber until the last one leaves (abort signal). Requires MongoDB to
+// run as a replica set (change streams are not available on standalone
+// deployments).
+async function MongoDBChangeStream({ connection, properties, publish, signal }) {
+  const { fullDocument, pipeline } = deserialize(properties ?? {});
+  const { collection, client } = await getCollection({ connection });
+  try {
+    if (signal.aborted) {
+      return;
+    }
+    const stream = collection.watch(pipeline ?? [], {
+      fullDocument: fullDocument ?? 'updateLookup',
+    });
+    signal.addEventListener(
+      'abort',
+      () => {
+        stream.close().catch(() => {
+          // Already closed — nothing to clean up.
+        });
+      },
+      { once: true }
+    );
+    try {
+      for await (const change of stream) {
+        publish({ data: serialize(change) });
+      }
+    } catch (error) {
+      // Closing the stream on abort surfaces as an error on the iterator.
+      if (!signal.aborted) {
+        throw error;
+      }
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+MongoDBChangeStream.schema = schema;
+MongoDBChangeStream.meta = {
+  publish: false,
+};
+
+export default MongoDBChangeStream;

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.test.js
@@ -1,0 +1,153 @@
+/*
+  Copyright 2020-2023 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+const mockGetCollection = jest.fn();
+
+jest.unstable_mockModule('../getCollection.js', () => ({
+  default: mockGetCollection,
+}));
+
+// A fake change stream: yields queued changes, then waits until close() ends it.
+function createFakeStream({ changes = [], failWith = null } = {}) {
+  let closed = false;
+  let release;
+  const closedPromise = new Promise((resolve) => {
+    release = resolve;
+  });
+  return {
+    watchCalls: [],
+    close: jest.fn(async () => {
+      closed = true;
+      release();
+    }),
+    async *[Symbol.asyncIterator]() {
+      for (const change of changes) {
+        yield change;
+      }
+      if (failWith) {
+        throw failWith;
+      }
+      await closedPromise;
+      if (closed) {
+        const error = new Error('ChangeStream is closed');
+        throw error;
+      }
+    },
+  };
+}
+
+function createHarness({ changes, failWith } = {}) {
+  const stream = createFakeStream({ changes, failWith });
+  const client = { close: jest.fn() };
+  const collection = { watch: jest.fn(() => stream) };
+  mockGetCollection.mockResolvedValue({ client, collection });
+  const publish = jest.fn();
+  const abortController = new AbortController();
+  return { abortController, client, collection, publish, stream };
+}
+
+beforeEach(() => {
+  mockGetCollection.mockReset();
+});
+
+test('MongoDBChangeStream publishes serialized change events', async () => {
+  const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
+  const createdAt = new Date('2026-01-15T00:00:00.000Z');
+  const { abortController, client, publish } = createHarness({
+    changes: [
+      { operationType: 'insert', fullDocument: { name: 'one', createdAt } },
+      { operationType: 'update', fullDocument: { name: 'two' } },
+    ],
+    failWith: new Error('ChangeStream is closed'),
+  });
+  abortController.abort(); // makes the trailing iterator error an expected abort
+  const run = MongoDBChangeStream({
+    connection: { databaseUri: 'mongodb://test' },
+    properties: {},
+    publish,
+    signal: abortController.signal,
+  });
+  await run;
+  expect(publish).toHaveBeenCalledTimes(0); // aborted before start — resolver returns early
+  expect(client.close).toHaveBeenCalled();
+});
+
+test('MongoDBChangeStream publishes events until aborted', async () => {
+  const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
+  const createdAt = new Date('2026-01-15T00:00:00.000Z');
+  const { abortController, client, collection, publish, stream } = createHarness({
+    changes: [
+      { operationType: 'insert', fullDocument: { name: 'one', createdAt } },
+      { operationType: 'update', fullDocument: { name: 'two' } },
+    ],
+  });
+  const run = MongoDBChangeStream({
+    connection: { databaseUri: 'mongodb://test' },
+    properties: { pipeline: [{ $match: { operationType: 'insert' } }] },
+    publish,
+    signal: abortController.signal,
+  });
+  // Give the async iterator a tick to consume the queued changes.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  abortController.abort();
+  await run;
+
+  expect(collection.watch).toHaveBeenCalledWith([{ $match: { operationType: 'insert' } }], {
+    fullDocument: 'updateLookup',
+  });
+  expect(publish).toHaveBeenCalledTimes(2);
+  // The plugin serialize util only marks MongoDB types (ObjectId → _oid);
+  // Dates pass through — the framework serializer handles them (~d) when the
+  // channel registry serializes the published frame.
+  expect(publish.mock.calls[0][0].data.fullDocument.createdAt).toEqual(createdAt);
+  expect(publish.mock.calls[1][0].data.fullDocument.name).toEqual('two');
+  expect(stream.close).toHaveBeenCalled();
+  expect(client.close).toHaveBeenCalled();
+});
+
+test('MongoDBChangeStream passes fullDocument option through', async () => {
+  const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
+  const { abortController, collection, publish } = createHarness({ changes: [] });
+  const run = MongoDBChangeStream({
+    connection: { databaseUri: 'mongodb://test' },
+    properties: { fullDocument: 'whenAvailable' },
+    publish,
+    signal: abortController.signal,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  abortController.abort();
+  await run;
+  expect(collection.watch).toHaveBeenCalledWith([], { fullDocument: 'whenAvailable' });
+});
+
+test('MongoDBChangeStream rethrows stream errors when not aborted', async () => {
+  const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
+  const { abortController, client, publish } = createHarness({
+    changes: [],
+    failWith: new Error('stream broke'),
+  });
+  await expect(
+    MongoDBChangeStream({
+      connection: { databaseUri: 'mongodb://test' },
+      properties: {},
+      publish,
+      signal: abortController.signal,
+    })
+  ).rejects.toThrow('stream broke');
+  expect(client.close).toHaveBeenCalled();
+});

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/schema.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/schema.js
@@ -1,0 +1,37 @@
+/*
+  Copyright 2020-2023 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export default {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Lowdefy Websocket Schema - MongoDBChangeStream',
+  type: 'object',
+  properties: {
+    pipeline: {
+      type: 'array',
+      description:
+        'Aggregation pipeline stages applied to the change stream (e.g. $match on operationType or fullDocument fields).',
+    },
+    fullDocument: {
+      type: 'string',
+      default: 'updateLookup',
+      description:
+        'The fullDocument option for the change stream. "updateLookup" includes the current document on updates.',
+    },
+  },
+  errorMessage: {
+    type: 'MongoDBChangeStream properties should be an object.',
+  },
+};

--- a/plugins/community-plugin-mongodb/src/types.js
+++ b/plugins/community-plugin-mongodb/src/types.js
@@ -2,6 +2,7 @@
 
 import * as adapters from './auth/adapters.js';
 import * as connections from './connections.js';
+import * as websockets from './websockets.js';
 
 export default {
   auth: {
@@ -11,4 +12,5 @@ export default {
   requests: Object.keys(connections)
     .map((connection) => Object.keys(connections[connection].requests))
     .flat(),
+  websockets: Object.keys(websockets),
 };

--- a/plugins/community-plugin-mongodb/src/websockets.js
+++ b/plugins/community-plugin-mongodb/src/websockets.js
@@ -1,0 +1,17 @@
+/*
+  Copyright 2020-2023 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+export { default as MongoDBChangeStream } from './connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.js';


### PR DESCRIPTION
## Summary

Adds a `MongoDBChangeStream` websocket type to `@lowdefy/community-plugin-mongodb`, mirroring the type added to the core `@lowdefy/connection-mongodb` plugin. It opens a MongoDB [change stream](https://www.mongodb.com/docs/manual/changeStreams/) on the connection's collection and pushes change events to subscribed pages in real time — the source starts with the first subscriber and stops with the last, and `pipeline` properties evaluate per subscription so `_user`/`_payload` operators produce user-specific streams.

Depends on the websockets primitive landing in Lowdefy v5.4 ([lowdefy/lowdefy#2213](https://github.com/lowdefy/lowdefy/pull/2213)).

## Changes

- **@lowdefy/community-plugin-mongodb**: New `MongoDBChangeStream` websocket resolver (with schema and unit tests), registered via a `websockets` types category and a `./websockets` package export. Docs page gains a Websockets section with a refetch-on-change example.

## Notes

- Change streams require MongoDB to run as a replica set (Atlas supports them out of the box); the unit tests mock the stream, matching how the plugin's other tests avoid replica-set requirements.
- No behavior change for existing connections/requests — the new export is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KvAuyqrp9RupoPrXHShJR