### PR TITLE
fix(community-plugin-mongodb): reuse a shared MongoClient per connection URI

### DIFF
--- a/.changeset/mongodb-shared-client.md
+++ b/.changeset/mongodb-shared-client.md
@@ -1,0 +1,5 @@
+---
+'@lowdefy/community-plugin-mongodb': patch
+---
+
+Reuse a shared MongoClient per connection URI instead of creating and closing a new client on every request, preventing connection/thread exhaustion under sustained load.

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.js
@@ -25,35 +25,35 @@ import schema from './schema.js';
 // deployments).
 async function MongoDBChangeStream({ connection, properties, publish, signal }) {
   const { fullDocument, pipeline } = deserialize(properties ?? {});
-  const { collection, client } = await getCollection({ connection });
+  const { collection } = await getCollection({ connection });
+  if (signal.aborted) {
+    return;
+  }
+  const stream = collection.watch(pipeline ?? [], {
+    fullDocument: fullDocument ?? 'updateLookup',
+  });
+  signal.addEventListener(
+    'abort',
+    () => {
+      stream.close().catch(() => {
+        // Already closed — nothing to clean up.
+      });
+    },
+    { once: true }
+  );
   try {
-    if (signal.aborted) {
-      return;
+    for await (const change of stream) {
+      publish({ data: serialize(change) });
     }
-    const stream = collection.watch(pipeline ?? [], {
-      fullDocument: fullDocument ?? 'updateLookup',
-    });
-    signal.addEventListener(
-      'abort',
-      () => {
-        stream.close().catch(() => {
-          // Already closed — nothing to clean up.
-        });
-      },
-      { once: true }
-    );
-    try {
-      for await (const change of stream) {
-        publish({ data: serialize(change) });
-      }
-    } catch (error) {
-      // Closing the stream on abort surfaces as an error on the iterator.
-      if (!signal.aborted) {
-        throw error;
-      }
+  } catch (error) {
+    // Closing the stream on abort surfaces as an error on the iterator.
+    if (!signal.aborted) {
+      throw error;
     }
   } finally {
-    await client.close();
+    // Tear down only the change stream — the MongoClient is shared across
+    // requests and must stay open. Closing an already-closed stream is a no-op.
+    await stream.close().catch(() => {});
   }
 }
 

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBChangeStream/MongoDBChangeStream.test.js
@@ -84,7 +84,8 @@ test('MongoDBChangeStream publishes serialized change events', async () => {
   });
   await run;
   expect(publish).toHaveBeenCalledTimes(0); // aborted before start — resolver returns early
-  expect(client.close).toHaveBeenCalled();
+  // The shared MongoClient must never be closed by a request.
+  expect(client.close).not.toHaveBeenCalled();
 });
 
 test('MongoDBChangeStream publishes events until aborted', async () => {
@@ -117,7 +118,8 @@ test('MongoDBChangeStream publishes events until aborted', async () => {
   expect(publish.mock.calls[0][0].data.fullDocument.createdAt).toEqual(createdAt);
   expect(publish.mock.calls[1][0].data.fullDocument.name).toEqual('two');
   expect(stream.close).toHaveBeenCalled();
-  expect(client.close).toHaveBeenCalled();
+  // Tearing down tears down the stream, not the shared client.
+  expect(client.close).not.toHaveBeenCalled();
 });
 
 test('MongoDBChangeStream passes fullDocument option through', async () => {
@@ -137,7 +139,7 @@ test('MongoDBChangeStream passes fullDocument option through', async () => {
 
 test('MongoDBChangeStream rethrows stream errors when not aborted', async () => {
   const { default: MongoDBChangeStream } = await import('./MongoDBChangeStream.js');
-  const { abortController, client, publish } = createHarness({
+  const { abortController, client, publish, stream } = createHarness({
     changes: [],
     failWith: new Error('stream broke'),
   });
@@ -149,5 +151,7 @@ test('MongoDBChangeStream rethrows stream errors when not aborted', async () => 
       signal: abortController.signal,
     })
   ).rejects.toThrow('stream broke');
-  expect(client.close).toHaveBeenCalled();
+  // The stream is torn down; the shared client is left open.
+  expect(stream.close).toHaveBeenCalled();
+  expect(client.close).not.toHaveBeenCalled();
 });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.js
@@ -29,29 +29,22 @@ async function MongodbDeleteMany({
 }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection, client, logCollection } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.deleteMany(filter, options);
-    if (logCollection) {
-      await logCollection.insertOne({
-        args: { filter, options },
-        blockId,
-        connectionId,
-        pageId,
-        payload,
-        requestId,
-        response,
-        timestamp: new Date(),
-        type: 'MongoDBDeleteMany',
-        meta: connection.changeLog?.meta,
-      });
-    }
-  } catch (error) {
-    await client.close();
-    throw error;
+  const { collection, logCollection } = await getCollection({ connection });
+  const response = await collection.deleteMany(filter, options);
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { filter, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBDeleteMany',
+      meta: connection.changeLog?.meta,
+    });
   }
-  await client.close();
   const { acknowledged, deletedCount } = serialize(response);
   return { acknowledged, deletedCount };
 }

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteMany/MongoDBDeleteMany.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBDeleteMany from './MongoDBDeleteMany.js';
+import { closeClients } from '../getCollection.js';
 import findLogCollectionRecordTestMongoDb from '../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../test/populateTestMongoDb.js';
 
@@ -42,6 +43,12 @@ const documents = [
   { _id: 'deleteMany_5_log', f: 'deleteMany_log' },
   { _id: 'deleteMany_6_log', f: 'deleteMany_log' },
 ];
+
+afterAll(async () => {
+  // getCollection now shares one MongoClient per connection for the process
+  // lifetime; close it so the test worker can exit cleanly.
+  await closeClients();
+});
 
 beforeAll(() => {
   return populateTestMongoDb({ collection, documents });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.js
@@ -29,39 +29,33 @@ async function MongodbDeleteOne({
 }) {
   const deserializedRequest = deserialize(request);
   const { filter, options } = deserializedRequest;
-  const { collection, client, logCollection } = await getCollection({ connection });
+  const { collection, logCollection } = await getCollection({ connection });
   let response;
-  try {
-    if (logCollection) {
-      const result = await collection.findOneAndDelete(filter, {
-        ...options,
-        includeResultMetadata: true,
-      });
-      const before = result.value ?? null;
-      response = {
-        acknowledged: true,
-        deletedCount: result.lastErrorObject?.n ?? 0,
-      };
-      await logCollection.insertOne({
-        args: { filter, options },
-        blockId,
-        connectionId,
-        pageId,
-        payload,
-        requestId,
-        before,
-        timestamp: new Date(),
-        type: 'MongoDBDeleteOne',
-        meta: connection.changeLog?.meta,
-      });
-    } else {
-      response = await collection.deleteOne(filter, options);
-    }
-  } catch (error) {
-    await client.close();
-    throw error;
+  if (logCollection) {
+    const result = await collection.findOneAndDelete(filter, {
+      ...options,
+      includeResultMetadata: true,
+    });
+    const before = result.value ?? null;
+    response = {
+      acknowledged: true,
+      deletedCount: result.lastErrorObject?.n ?? 0,
+    };
+    await logCollection.insertOne({
+      args: { filter, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      before,
+      timestamp: new Date(),
+      type: 'MongoDBDeleteOne',
+      meta: connection.changeLog?.meta,
+    });
+  } else {
+    response = await collection.deleteOne(filter, options);
   }
-  await client.close();
   return serialize(response);
 }
 

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBDeleteOne/MongoDBDeleteOne.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBDeleteOne from './MongoDBDeleteOne.js';
+import { closeClients } from '../getCollection.js';
 import findLogCollectionRecordTestMongoDb from '../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../test/populateTestMongoDb.js';
 
@@ -27,6 +28,12 @@ const databaseName = 'test';
 const collection = 'deleteOne';
 const logCollection = 'logCollection';
 const documents = [{ _id: 'deleteOne' }, { _id: 'deleteOne_log' }];
+
+afterAll(async () => {
+  // getCollection now shares one MongoClient per connection for the process
+  // lifetime; close it so the test worker can exit cleanly.
+  await closeClients();
+});
 
 beforeAll(() => {
   return populateTestMongoDb({ collection, documents });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/MongoDBInsertConsecutiveId.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertConsecutiveId/MongoDBInsertConsecutiveId.js
@@ -113,7 +113,6 @@ async function MongoDBInsertConsecutiveId({
     }, transactionOptions);
   } finally {
     await session.endSession();
-    await client.close();
   }
   const { acknowledged, insertedId } = serialize(response);
   return { acknowledged, insertedId };

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.js
@@ -29,29 +29,22 @@ async function MongodbInsertMany({
 }) {
   const deserializedRequest = deserialize(request);
   const { docs, options } = deserializedRequest;
-  const { collection, client, logCollection } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.insertMany(docs, options);
-    if (logCollection) {
-      await logCollection.insertOne({
-        args: { docs, options },
-        blockId,
-        connectionId,
-        pageId,
-        payload,
-        requestId,
-        response,
-        timestamp: new Date(),
-        type: 'MongoDBInsertMany',
-        meta: connection.changeLog?.meta,
-      });
-    }
-  } catch (error) {
-    await client.close();
-    throw error;
+  const { collection, logCollection } = await getCollection({ connection });
+  const response = await collection.insertMany(docs, options);
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { docs, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBInsertMany',
+      meta: connection.changeLog?.meta,
+    });
   }
-  await client.close();
   const { acknowledged, insertedCount, insertedIds } = serialize(response);
   return { acknowledged, insertedCount, insertedIds };
 }

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertMany/MongoDBInsertMany.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBInsertMany from './MongoDBInsertMany.js';
+import { closeClients } from '../getCollection.js';
 import clearTestMongoDb from '../../../test/clearTestMongoDb.js';
 import findLogCollectionRecordTestMongoDb from '../../../test/findLogCollectionRecordTestMongoDb.js';
 
@@ -26,6 +27,12 @@ const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'insertMany';
 const logCollection = 'logCollection';
+
+afterAll(async () => {
+  // getCollection now shares one MongoClient per connection for the process
+  // lifetime; close it so the test worker can exit cleanly.
+  await closeClients();
+});
 
 beforeAll(() => {
   return clearTestMongoDb({ collection });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/MongoDBInsertManyConsecutiveIds.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertManyConsecutiveIds/MongoDBInsertManyConsecutiveIds.js
@@ -115,7 +115,6 @@ async function MongoDBInsertManyConsecutiveIds({
     }, transactionOptions);
   } finally {
     await session.endSession();
-    await client.close();
   }
   const { acknowledged, insertedIds } = serialize(response);
   return { acknowledged, insertedIds };

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.js
@@ -29,29 +29,22 @@ async function MongodbInsertOne({
 }) {
   const deserializedRequest = deserialize(request);
   const { doc, options } = deserializedRequest;
-  const { collection, client, logCollection } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.insertOne(doc, options);
-    if (logCollection) {
-      await logCollection.insertOne({
-        args: { doc, options },
-        blockId,
-        connectionId,
-        pageId,
-        payload,
-        requestId,
-        response,
-        timestamp: new Date(),
-        type: 'MongoDBInsertOne',
-        meta: connection.changeLog?.meta,
-      });
-    }
-  } catch (error) {
-    await client.close();
-    throw error;
+  const { collection, logCollection } = await getCollection({ connection });
+  const response = await collection.insertOne(doc, options);
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { doc, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBInsertOne',
+      meta: connection.changeLog?.meta,
+    });
   }
-  await client.close();
   const { acknowledged, insertedId } = serialize(response);
   return { acknowledged, insertedId };
 }

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBInsertOne/MongoDBInsertOne.test.js
@@ -17,6 +17,7 @@
 import { validate } from '@lowdefy/ajv';
 import { MongoClient } from 'mongodb';
 import MongoDBInsertOne from './MongoDBInsertOne.js';
+import { closeClients } from '../getCollection.js';
 import clearTestMongoDb from '../../../test/clearTestMongoDb.js';
 import findLogCollectionRecordTestMongoDb from '../../../test/findLogCollectionRecordTestMongoDb.js';
 
@@ -27,6 +28,12 @@ const databaseUri = process.env.MONGO_URL;
 const databaseName = 'test';
 const collection = 'insertOne';
 const logCollection = 'logCollection';
+
+afterAll(async () => {
+  // getCollection now shares one MongoClient per connection for the process
+  // lifetime; close it so the test worker can exit cleanly.
+  await closeClients();
+});
 
 beforeAll(() => {
   return clearTestMongoDb({ collection });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.js
@@ -29,29 +29,22 @@ async function MongodbUpdateMany({
 }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options } = deserializedRequest;
-  const { collection, client, logCollection } = await getCollection({ connection });
-  let response;
-  try {
-    response = await collection.updateMany(filter, update, options);
-    if (logCollection) {
-      await logCollection.insertOne({
-        args: { filter, update, options },
-        blockId,
-        connectionId,
-        pageId,
-        payload,
-        requestId,
-        response,
-        timestamp: new Date(),
-        type: 'MongoDBUpdateMany',
-        meta: connection.changeLog?.meta,
-      });
-    }
-  } catch (error) {
-    await client.close();
-    throw error;
+  const { collection, logCollection } = await getCollection({ connection });
+  const response = await collection.updateMany(filter, update, options);
+  if (logCollection) {
+    await logCollection.insertOne({
+      args: { filter, update, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      response,
+      timestamp: new Date(),
+      type: 'MongoDBUpdateMany',
+      meta: connection.changeLog?.meta,
+    });
   }
-  await client.close();
   const { modifiedCount, upsertedId, upsertedCount, matchedCount } = serialize(response);
   return { modifiedCount, upsertedId, upsertedCount, matchedCount };
 }

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateMany/MongoDBUpdateMany.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBUpdateMany from './MongoDBUpdateMany.js';
+import { closeClients } from '../getCollection.js';
 import findLogCollectionRecordTestMongoDb from '../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../test/populateTestMongoDb.js';
 
@@ -35,6 +36,12 @@ const documents = [
   { _id: 'updateMany_5', v: 'before', f: 'updateMany' },
   { _id: 'updateMany_6', v: 'before', f: 'updateMany' },
 ];
+
+afterAll(async () => {
+  // getCollection now shares one MongoClient per connection for the process
+  // lifetime; close it so the test worker can exit cleanly.
+  await closeClients();
+});
 
 beforeAll(() => {
   return populateTestMongoDb({ collection, documents });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.js
@@ -29,53 +29,47 @@ async function MongodbUpdateOne({
 }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options, disableNoMatchError } = deserializedRequest;
-  const { collection, client, logCollection } = await getCollection({ connection });
+  const { collection, logCollection } = await getCollection({ connection });
   let response;
-  try {
-    if (logCollection) {
-      const before = await collection.findOne(filter);
-      const result = await collection.findOneAndUpdate(filter, update, {
-        ...options,
-        includeResultMetadata: true,
-        returnDocument: 'after',
-      });
-      const after = result.value ?? null;
-      const upsertedId = result.lastErrorObject?.upserted ?? null;
-      const matched = result.lastErrorObject?.updatedExisting ? 1 : 0;
-      response = {
-        acknowledged: true,
-        matchedCount: matched,
-        modifiedCount: matched,
-        upsertedId,
-        upsertedCount: upsertedId ? 1 : 0,
-      };
-      if (!disableNoMatchError && !options?.upsert && matched === 0 && !upsertedId) {
-        throw new Error('No matching record to update.');
-      }
-      await logCollection.insertOne({
-        args: { filter, update, options },
-        blockId,
-        connectionId,
-        pageId,
-        payload,
-        requestId,
-        before,
-        after,
-        timestamp: new Date(),
-        type: 'MongoDBUpdateOne',
-        meta: connection.changeLog?.meta,
-      });
-    } else {
-      response = await collection.updateOne(filter, update, options);
-      if (!disableNoMatchError && !options?.upsert && response.matchedCount === 0) {
-        throw new Error('No matching record to update.');
-      }
+  if (logCollection) {
+    const before = await collection.findOne(filter);
+    const result = await collection.findOneAndUpdate(filter, update, {
+      ...options,
+      includeResultMetadata: true,
+      returnDocument: 'after',
+    });
+    const after = result.value ?? null;
+    const upsertedId = result.lastErrorObject?.upserted ?? null;
+    const matched = result.lastErrorObject?.updatedExisting ? 1 : 0;
+    response = {
+      acknowledged: true,
+      matchedCount: matched,
+      modifiedCount: matched,
+      upsertedId,
+      upsertedCount: upsertedId ? 1 : 0,
+    };
+    if (!disableNoMatchError && !options?.upsert && matched === 0 && !upsertedId) {
+      throw new Error('No matching record to update.');
     }
-  } catch (error) {
-    await client.close();
-    throw error;
+    await logCollection.insertOne({
+      args: { filter, update, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      before,
+      after,
+      timestamp: new Date(),
+      type: 'MongoDBUpdateOne',
+      meta: connection.changeLog?.meta,
+    });
+  } else {
+    response = await collection.updateOne(filter, update, options);
+    if (!disableNoMatchError && !options?.upsert && response.matchedCount === 0) {
+      throw new Error('No matching record to update.');
+    }
   }
-  await client.close();
   return serialize(response);
 }
 

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBUpdateOne/MongoDBUpdateOne.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBUpdateOne from './MongoDBUpdateOne.js';
+import { closeClients } from '../getCollection.js';
 import findLogCollectionRecordTestMongoDb from '../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../test/populateTestMongoDb.js';
 
@@ -30,6 +31,12 @@ const documents = [
   { _id: 'updateOne', v: 'before' },
   { _id: null, v: 'sentinel' },
 ];
+
+afterAll(async () => {
+  // getCollection now shares one MongoClient per connection for the process
+  // lifetime; close it so the test worker can exit cleanly.
+  await closeClients();
+});
 
 beforeAll(() => {
   return populateTestMongoDb({ collection, documents });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.js
@@ -29,75 +29,69 @@ async function MongoDBVersionedUpdateOne({
 }) {
   const deserializedRequest = deserialize(request);
   const { filter, update, options, disableNoMatchError } = deserializedRequest;
-  const { collection, client, logCollection } = await getCollection({ connection });
+  const { collection, logCollection } = await getCollection({ connection });
   const findOptions = options?.find;
   const insertOptions = options?.insert;
   const updateOptions = options?.update;
   let response, insertedDocument;
 
-  try {
-    const document = await collection.findOne(filter, { ...findOptions });
-    if (logCollection) {
-      if (document) {
-        delete document._id;
-        insertedDocument = await collection.insertOne(document, { ...insertOptions });
-      }
-
-      const result = await collection.findOneAndUpdate(
-        insertedDocument ? { _id: insertedDocument.insertedId } : filter,
-        update,
-        {
-          ...updateOptions,
-          includeResultMetadata: true,
-          returnDocument: 'after',
-        }
-      );
-      const after = result.value ?? null;
-      const upsertedId = result.lastErrorObject?.upserted ?? null;
-      const matched = result.lastErrorObject?.updatedExisting ? 1 : 0;
-      response = {
-        acknowledged: true,
-        matchedCount: matched,
-        modifiedCount: matched,
-        upsertedId,
-        upsertedCount: upsertedId ? 1 : 0,
-      };
-      if (!disableNoMatchError && !updateOptions?.upsert && matched === 0 && !upsertedId) {
-        throw new Error('No matching record to update.');
-      }
-      await logCollection.insertOne({
-        args: { filter, update, options },
-        blockId,
-        connectionId,
-        pageId,
-        payload,
-        requestId,
-        before: document,
-        after,
-        timestamp: new Date(),
-        type: 'MongoDBVersionedUpdateOne',
-        meta: connection.changeLog?.meta,
-      });
-    } else {
-      if (document) {
-        delete document._id;
-        insertedDocument = await collection.insertOne(document, { ...insertOptions });
-      }
-
-      response = await collection.updateOne(
-        insertedDocument ? { _id: insertedDocument.insertedId } : filter,
-        update,
-        { ...updateOptions }
-      );
-      if (!disableNoMatchError && !updateOptions?.upsert && response.matchedCount === 0) {
-        throw new Error('No matching record to update.');
-      }
+  const document = await collection.findOne(filter, { ...findOptions });
+  if (logCollection) {
+    if (document) {
+      delete document._id;
+      insertedDocument = await collection.insertOne(document, { ...insertOptions });
     }
-  } catch (error) {
-    await client.close();
-    throw error;
+
+    const result = await collection.findOneAndUpdate(
+      insertedDocument ? { _id: insertedDocument.insertedId } : filter,
+      update,
+      {
+        ...updateOptions,
+        includeResultMetadata: true,
+        returnDocument: 'after',
+      }
+    );
+    const after = result.value ?? null;
+    const upsertedId = result.lastErrorObject?.upserted ?? null;
+    const matched = result.lastErrorObject?.updatedExisting ? 1 : 0;
+    response = {
+      acknowledged: true,
+      matchedCount: matched,
+      modifiedCount: matched,
+      upsertedId,
+      upsertedCount: upsertedId ? 1 : 0,
+    };
+    if (!disableNoMatchError && !updateOptions?.upsert && matched === 0 && !upsertedId) {
+      throw new Error('No matching record to update.');
+    }
+    await logCollection.insertOne({
+      args: { filter, update, options },
+      blockId,
+      connectionId,
+      pageId,
+      payload,
+      requestId,
+      before: document,
+      after,
+      timestamp: new Date(),
+      type: 'MongoDBVersionedUpdateOne',
+      meta: connection.changeLog?.meta,
+    });
+  } else {
+    if (document) {
+      delete document._id;
+      insertedDocument = await collection.insertOne(document, { ...insertOptions });
+    }
+
+    response = await collection.updateOne(
+      insertedDocument ? { _id: insertedDocument.insertedId } : filter,
+      update,
+      { ...updateOptions }
+    );
+    if (!disableNoMatchError && !updateOptions?.upsert && response.matchedCount === 0) {
+      throw new Error('No matching record to update.');
+    }
   }
-  await client.close();
   return serialize(response);
 }
 

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/MongoDBVersionedUpdateOne/MongoDBVersionedUpdateOne.test.js
@@ -16,6 +16,7 @@
 
 import { validate } from '@lowdefy/ajv';
 import MongoDBVersionedUpdateOne from './MongoDBVersionedUpdateOne.js';
+import { closeClients } from '../getCollection.js';
 import findLogCollectionRecordTestMongoDb from '../../../test/findLogCollectionRecordTestMongoDb.js';
 import populateTestMongoDb from '../../../test/populateTestMongoDb.js';
 import getTestCollection from '../../../test/getTestCollection.js';
@@ -28,6 +29,12 @@ const databaseName = 'test';
 const collection = 'updateInsertOne';
 const logCollection = 'logCollection';
 const documents = [{ _id: 'uniqueId', v: 'before', doc_id: 'updateInsertOne' }];
+
+afterAll(async () => {
+  // getCollection now shares one MongoClient per connection for the process
+  // lifetime; close it so the test worker can exit cleanly.
+  await closeClients();
+});
 
 beforeEach(() => {
   return populateTestMongoDb({ collection, documents });

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/getCollection.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/getCollection.js
@@ -16,22 +16,62 @@
 
 import { MongoClient } from 'mongodb';
 
-async function getCollection({ connection }) {
-  let client;
-  const { collection, databaseName, databaseUri, changeLog, options } = connection;
-  client = new MongoClient(databaseUri, options);
-  await client.connect();
-  try {
-    const db = client.db(databaseName);
-    return {
-      client,
-      collection: db.collection(collection),
-      logCollection: changeLog?.collection && db.collection(changeLog.collection),
-    };
-  } catch (error) {
-    await client.close();
-    throw error;
-  }
+// A MongoClient owns an internal connection pool and is designed to be created
+// once per connection and shared for the lifetime of the process. Creating a
+// new client (and connect/close) per request churns server connections and,
+// under sustained load, exhausts the server's per-process thread limit.
+//
+// Cache one connected client per (databaseUri + serialized options). The value
+// stored is the connect() promise itself, so concurrent first calls share a
+// single connect. If connect() fails the entry is evicted so a later call can
+// retry.
+const clients = new Map();
+
+function getClientCacheKey({ databaseUri, options }) {
+  return `${databaseUri}::${JSON.stringify(options ?? {})}`;
 }
 
+function getClient({ databaseUri, options }) {
+  const cacheKey = getClientCacheKey({ databaseUri, options });
+  let connecting = clients.get(cacheKey);
+  if (!connecting) {
+    const client = new MongoClient(databaseUri, options);
+    connecting = client.connect().catch((error) => {
+      clients.delete(cacheKey);
+      throw error;
+    });
+    clients.set(cacheKey, connecting);
+  }
+  return connecting;
+}
+
+// Close every cached client and clear the cache. Intended for graceful
+// shutdown and for test teardown; not needed during normal request handling.
+async function closeClients() {
+  const closing = [];
+  for (const connecting of clients.values()) {
+    closing.push(
+      Promise.resolve(connecting)
+        .then((client) => client.close())
+        .catch(() => {
+          // Ignore errors while closing — we are tearing down anyway.
+        })
+    );
+  }
+  clients.clear();
+  await Promise.all(closing);
+}
+
+async function getCollection({ connection }) {
+  const { collection, databaseName, databaseUri, changeLog, options } = connection;
+  const client = await getClient({ databaseUri, options });
+  const db = client.db(databaseName);
+  return {
+    client,
+    collection: db.collection(collection),
+    logCollection: changeLog?.collection && db.collection(changeLog.collection),
+  };
+}
+
+export { closeClients };
 export default getCollection;

--- a/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/getCollection.test.js
+++ b/plugins/community-plugin-mongodb/src/connections/MongoDBCollection/getCollection.test.js
@@ -1,0 +1,111 @@
+/*
+  Copyright 2020-2023 Lowdefy, Inc
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { jest } from '@jest/globals';
+
+// Tracks every MongoClient the module under test constructs, and lets each
+// test steer what connect() does.
+const instances = [];
+let connectImpl = (client) => Promise.resolve(client);
+
+jest.unstable_mockModule('mongodb', () => ({
+  MongoClient: class MongoClient {
+    constructor(uri, options) {
+      this.uri = uri;
+      this.options = options;
+      this.connect = jest.fn(() => connectImpl(this));
+      this.db = jest.fn(() => ({ collection: jest.fn((name) => ({ name })) }));
+      this.close = jest.fn(async () => {});
+      instances.push(this);
+    }
+  },
+}));
+
+let getCollection;
+let closeClients;
+
+beforeAll(async () => {
+  ({ default: getCollection, closeClients } = await import('./getCollection.js'));
+});
+
+beforeEach(async () => {
+  await closeClients();
+  instances.length = 0;
+  connectImpl = (client) => Promise.resolve(client);
+});
+
+const baseConnection = {
+  databaseUri: 'mongodb://localhost:27017',
+  databaseName: 'test',
+  collection: 'things',
+};
+
+test('reuses a single client for the same uri and options', async () => {
+  const connection = { ...baseConnection, options: { maxPoolSize: 10 } };
+  const first = await getCollection({ connection });
+  const second = await getCollection({ connection });
+
+  expect(first.client).toBe(second.client);
+  expect(instances).toHaveLength(1);
+  expect(instances[0].connect).toHaveBeenCalledTimes(1);
+});
+
+test('concurrent first calls share a single connect', async () => {
+  let resolveConnect;
+  connectImpl = (client) =>
+    new Promise((resolve) => {
+      resolveConnect = () => resolve(client);
+    });
+  const connection = { ...baseConnection, options: { maxPoolSize: 10 } };
+
+  const pending = Promise.all([getCollection({ connection }), getCollection({ connection })]);
+  resolveConnect();
+  const [first, second] = await pending;
+
+  expect(first.client).toBe(second.client);
+  expect(instances).toHaveLength(1);
+  expect(instances[0].connect).toHaveBeenCalledTimes(1);
+});
+
+test('creates separate clients for different options', async () => {
+  const first = await getCollection({
+    connection: { ...baseConnection, options: { maxPoolSize: 10 } },
+  });
+  const second = await getCollection({
+    connection: { ...baseConnection, options: { maxPoolSize: 20 } },
+  });
+
+  expect(first.client).not.toBe(second.client);
+  expect(instances).toHaveLength(2);
+});
+
+test('evicts a failed connect so the next call retries', async () => {
+  let attempt = 0;
+  connectImpl = (client) => {
+    attempt += 1;
+    if (attempt === 1) {
+      return Promise.reject(new Error('connect failed'));
+    }
+    return Promise.resolve(client);
+  };
+  const connection = { ...baseConnection, options: { maxPoolSize: 10 } };
+
+  await expect(getCollection({ connection })).rejects.toThrow('connect failed');
+  const retried = await getCollection({ connection });
+
+  expect(retried.client).toBeDefined();
+  expect(instances).toHaveLength(2);
+});


### PR DESCRIPTION
## Problem

`getCollection.js` created a **new `MongoClient` and called `connect()` on every request**, and each request method then `await client.close()`-ed it in a `finally` block. A `MongoClient` owns an internal connection pool and is meant to be created once and shared for the process lifetime, so this per-request connect/close churn is both slow and unsafe under load.

Under sustained load (a long-running ERP simulation driving a Lowdefy app, and long Playwright e2e suites) the constant connect/close plus overlapping long-lived connections drove `mongod` past the OS per-process thread limit — `mongod` died with `pthread_create failed: Resource temporarily unavailable` (peak observed `connectionCount` 4034 on macOS's ~4k cap). Downstream symptoms were `MongoNetworkError: connection closed` late in long test suites, degraded throughput, and eventual `mongod` crashes.

## Fix

- **Memoize one `MongoClient` per `(databaseUri, JSON.stringify(options))`** in a module-level `Map` in `getCollection.js`. The cached value is the `connect()` promise itself, so concurrent first calls share a single connect; on connect failure the entry is evicted so a later call retries.
- **Remove the per-request `await client.close()`** from every request method (`MongoDBInsertOne/Many`, `MongoDBUpdateOne/Many`, `MongoDBDeleteOne/Many`, `MongoDBVersionedUpdateOne`, and the consecutive-id variants). The shared client must outlive individual requests. Where the `try/catch` existed only to close on error, it was removed; sessions in the consecutive-id methods are still ended in `finally`.
- **`MongoDBChangeStream`** now tears down only the change stream (in `finally`) instead of closing the shared client.
- Added `closeClients()` (exported) for graceful shutdown / test teardown.

## Compatibility notes

- **Transactions are unaffected.** `client.startSession()` on a shared client is the driver-recommended pattern; sessions are still created and ended per request.
- **Distinct connections stay distinct.** The `options` object is part of the cache key, so connections that differ only by options get separate clients.
- **Clients live for the process lifetime**, which is the intended `MongoClient` lifecycle.

## Testing

- Package jest suite green: **9 suites, 133 tests passing**, process exits cleanly (no leaked handles).
- Updated the `MongoDBChangeStream` assertions (the shared client is no longer closed; the stream is torn down instead) and added `afterAll(closeClients)` teardown to the integration suites.
- Added `getCollection.test.js` proving: (a) same uri+options share one client, (b) different options get different clients, (c) a failed connect is evicted and retried, plus concurrent first-call dedupe.
- Downstream load-test evidence: a 12-month ERP simulation that previously killed `mongod` at ~4k connections now runs with a bounded pool.

A changeset (`patch`) is included.
